### PR TITLE
feat(sprint-1): OCR + Claude correction engine + error report UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build/
 venv/
 env/
 .venv/
+.venv
 
 # Streamlit
 .streamlit/

--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 """
 LacDictée — AI-powered French dictation correction for teachers.
-
-Entry point: streamlit run app.py
+Run: streamlit run app.py
 """
 
 import streamlit as st
@@ -17,61 +16,108 @@ st.set_page_config(
     layout="centered",
 )
 
+# ── Header ──────────────────────────────────────────────────────────────────
 st.title("🇫🇷 LacDictée")
 st.caption("AI-powered French dictation correction for teachers")
+st.divider()
 
-# --- Step 1: Upload ---
-st.header("Step 1 — Upload student's dictation photo")
+# ── Step 1: Upload ───────────────────────────────────────────────────────────
+st.subheader("Step 1 — Upload student's dictation photo")
 uploaded_file = st.file_uploader(
     "Upload a photo of the student's handwritten dictation",
     type=["jpg", "jpeg", "png"],
+    help="Take a clear photo in good lighting. The app supports jpg and png.",
 )
 
 ocr_text = ""
-if uploaded_file:
-    st.image(uploaded_file, caption="Uploaded dictation", use_container_width=True)
-    with st.spinner("Reading handwriting with OCR…"):
-        ocr_text = extract_text_from_image(uploaded_file)
-    st.subheader("Extracted text (OCR)")
-    ocr_text = st.text_area("Edit if OCR made mistakes:", value=ocr_text, height=150)
+ocr_confidence = None
 
-# --- Step 2: Correct text ---
-st.header("Step 2 — Enter the correct dictation text")
+if uploaded_file:
+    col_img, col_info = st.columns([2, 1])
+    with col_img:
+        st.image(uploaded_file, caption="Uploaded dictation", use_container_width=True)
+
+    with st.spinner("Reading handwriting with OCR…"):
+        uploaded_file.seek(0)
+        result = extract_text_from_image(uploaded_file)
+        ocr_text = result.text
+        ocr_confidence = result.confidence
+
+    if result.warning:
+        st.warning(result.warning)
+    else:
+        conf_pct = int(ocr_confidence * 100)
+        st.success(f"OCR completed — confidence: {conf_pct}%")
+
+    st.subheader("Extracted text (OCR)")
+    st.caption("Review and correct any OCR mistakes before proceeding.")
+    ocr_text = st.text_area(
+        "Student text:",
+        value=ocr_text,
+        height=140,
+        key="ocr_text_area",
+    )
+
+st.divider()
+
+# ── Step 2: Correct text ─────────────────────────────────────────────────────
+st.subheader("Step 2 — Enter the correct dictation text")
 correct_text = st.text_area(
-    "Type or paste the original correct text:",
-    height=150,
+    "Reference text (what the student should have written):",
+    height=140,
     placeholder="Le chat mange une souris dans le jardin.",
+    key="correct_text_area",
 )
 
-# --- Step 3: Correct ---
-if st.button("✅ Correct dictation", disabled=not (ocr_text and correct_text)):
+# ── Step 3: Run correction ────────────────────────────────────────────────────
+st.divider()
+run_disabled = not (ocr_text.strip() and correct_text.strip())
+if run_disabled and (uploaded_file or correct_text):
+    st.info("Upload a photo and enter the correct text to run the correction.")
+
+if st.button("✅ Correct dictation", disabled=run_disabled, use_container_width=True):
     with st.spinner("Claude is analysing errors…"):
-        result = correct_dictation(
+        correction = correct_dictation(
             student_text=ocr_text,
             correct_text=correct_text,
         )
 
-    # --- Step 4: Report ---
-    st.header("Step 3 — Error Report")
+    st.divider()
+    st.subheader("Step 3 — Error Report")
 
-    score = result.get("score", 0)
-    errors = result.get("errors", [])
-    total_words = result.get("total_words", 1)
-
+    # ── Score metrics ─────────────────────────────────────────────────────────
     col1, col2, col3 = st.columns(3)
-    col1.metric("Score", f"{score}/100")
-    col2.metric("Errors", len(errors))
-    col3.metric("Total words", total_words)
+    score_color = "green" if correction.score >= 80 else "orange" if correction.score >= 60 else "red"
+    col1.metric("Score", f"{correction.score} / 100")
+    col2.metric("Errors found", correction.error_count)
+    col3.metric("Total words", correction.total_words)
 
-    if errors:
-        st.subheader("Errors")
-        for err in errors:
-            color = {"spelling": "🔴", "grammar": "🟠", "accent": "🟡"}.get(
-                err.get("type", "spelling"), "⚪"
-            )
-            st.markdown(
-                f"{color} **{err.get('wrong', '')}** → `{err.get('correct', '')}` "
-                f"*({err.get('type', '')})*: {err.get('explanation', '')}"
-            )
+    if correction.error_count == 0:
+        st.success("🎉 Perfect dictation! No errors found.")
     else:
-        st.success("Perfect dictation! No errors found.")
+        # ── Error type breakdown ──────────────────────────────────────────────
+        st.subheader("Error breakdown")
+        type_labels = {
+            "spelling":     ("🔴", "Spelling"),
+            "grammar":      ("🟠", "Grammar"),
+            "accent":       ("🟡", "Accent"),
+            "missing_word": ("🔵", "Missing word"),
+            "extra_word":   ("⚪", "Extra word"),
+        }
+        by_type = correction.errors_by_type
+        cols = st.columns(len(by_type) if by_type else 1)
+        for i, (etype, count) in enumerate(by_type.items()):
+            icon, label = type_labels.get(etype, ("⚫", etype))
+            cols[i].metric(f"{icon} {label}", count)
+
+        # ── Error list ────────────────────────────────────────────────────────
+        st.subheader("Errors")
+        for err in correction.errors:
+            icon, label = type_labels.get(err.type, ("⚫", err.type))
+            with st.expander(f"{icon} **{err.wrong}** → `{err.correct}` ({label})"):
+                st.write(err.explanation)
+
+    # ── Store result in session for future PDF export (Sprint 2) ─────────────
+    st.session_state["last_correction"] = correction
+    st.session_state["last_ocr_text"] = ocr_text
+    st.session_state["last_correct_text"] = correct_text

--- a/src/correction.py
+++ b/src/correction.py
@@ -1,11 +1,40 @@
 """
 Correction module — uses Claude AI to compare student text vs correct text
-and return a structured error report.
+and return a structured error report with explanations.
 """
 
 import os
 import json
 import anthropic
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class DictationError:
+    wrong: str
+    correct: str
+    type: str       # spelling | grammar | accent | missing_word | extra_word
+    explanation: str
+
+
+@dataclass
+class CorrectionResult:
+    score: int                         # 0–100
+    total_words: int
+    errors: List[DictationError] = field(default_factory=list)
+
+    @property
+    def error_count(self) -> int:
+        return len(self.errors)
+
+    @property
+    def errors_by_type(self) -> dict:
+        counts: dict = {}
+        for e in self.errors:
+            counts[e.type] = counts.get(e.type, 0) + 1
+        return counts
+
 
 _client = None
 
@@ -13,70 +42,110 @@ _client = None
 def _get_client() -> anthropic.Anthropic:
     global _client
     if _client is None:
-        _client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "ANTHROPIC_API_KEY not set. Add it to your .env file."
+            )
+        _client = anthropic.Anthropic(api_key=api_key)
     return _client
 
 
-SYSTEM_PROMPT = """You are an expert French language teacher.
-You receive two texts:
-1. The student's text (extracted via OCR from handwriting — may contain OCR artifacts)
-2. The correct reference text
+_SYSTEM_PROMPT = """\
+You are an expert French language teacher and proofreader.
 
-Your job is to compare them word by word and identify every error.
+You receive:
+1. STUDENT TEXT — extracted via OCR from a student's handwriting (may have OCR artifacts)
+2. CORRECT TEXT — the original reference dictation
 
-Respond ONLY with valid JSON in this exact format:
+Your task: compare them word by word and identify every error the student made.
+
+Respond ONLY with valid JSON in this exact schema (no markdown, no explanation outside the JSON):
 {
   "score": <integer 0-100>,
-  "total_words": <integer>,
+  "total_words": <integer — count of words in CORRECT TEXT>,
   "errors": [
     {
-      "wrong": "<what the student wrote>",
+      "wrong": "<exact word or phrase the student wrote>",
       "correct": "<what it should be>",
       "type": "<spelling|grammar|accent|missing_word|extra_word>",
-      "explanation": "<short explanation in English>"
+      "explanation": "<one-sentence explanation in English>"
     }
   ]
 }
 
-Rules:
-- Score = 100 - (errors / total_words * 100), minimum 0
-- Ignore minor OCR artifacts that are clearly not student mistakes
-- Be strict about French accents (é vs e = accent error)
-- Do not include any text outside the JSON object"""
+Error type definitions:
+- spelling:      wrong letters (e.g. "maision" instead of "maison")
+- grammar:       wrong verb form, wrong gender/number agreement
+- accent:        correct letters but wrong or missing accent (e.g. "eleve" instead of "élève")
+- missing_word:  student skipped a word entirely
+- extra_word:    student added a word not in the original
+
+Score formula: score = max(0, round(100 - (error_count / total_words * 100)))
+
+Important:
+- Ignore minor OCR artifacts (stray characters, punctuation noise) that are clearly not student errors
+- Be strict about French accents — they are graded separately
+- Do not add any text, explanation, or markdown outside the JSON object\
+"""
 
 
-def correct_dictation(student_text: str, correct_text: str) -> dict:
+def correct_dictation(student_text: str, correct_text: str) -> CorrectionResult:
     """
-    Compare student's dictation against the correct text using Claude.
+    Compare student's dictation against the correct reference using Claude.
 
     Args:
-        student_text: OCR-extracted text from student's handwriting
-        correct_text: The original correct dictation text
+        student_text: OCR-extracted text from the student's handwriting
+        correct_text: The teacher's original correct dictation text
 
     Returns:
-        dict with keys: score (int), total_words (int), errors (list)
+        CorrectionResult with score, total_words, and list of DictationError objects.
+
+    Raises:
+        RuntimeError: if ANTHROPIC_API_KEY is not set
+        ValueError: if Claude returns malformed JSON
     """
     client = _get_client()
-
-    user_message = f"""STUDENT TEXT:
-{student_text}
-
-CORRECT TEXT:
-{correct_text}"""
 
     message = client.messages.create(
         model="claude-sonnet-4-6",
         max_tokens=2048,
-        system=SYSTEM_PROMPT,
-        messages=[{"role": "user", "content": user_message}],
+        system=_SYSTEM_PROMPT,
+        messages=[
+            {
+                "role": "user",
+                "content": (
+                    f"STUDENT TEXT:\n{student_text}\n\n"
+                    f"CORRECT TEXT:\n{correct_text}"
+                ),
+            }
+        ],
     )
 
     raw = message.content[0].text.strip()
 
-    # Strip markdown code fences if Claude wraps the JSON
+    # Strip markdown code fences if present
     if raw.startswith("```"):
-        raw = raw.split("```")[1]
-        if raw.startswith("json"):
-            raw = raw[4:]
+        lines = raw.split("\n")
+        raw = "\n".join(lines[1:-1] if lines[-1] == "```" else lines[1:])
 
-    return json.loads(raw)
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Claude returned invalid JSON: {e}\nRaw response: {raw[:200]}")
+
+    errors = [
+        DictationError(
+            wrong=err.get("wrong", ""),
+            correct=err.get("correct", ""),
+            type=err.get("type", "spelling"),
+            explanation=err.get("explanation", ""),
+        )
+        for err in data.get("errors", [])
+    ]
+
+    return CorrectionResult(
+        score=int(data.get("score", 0)),
+        total_words=int(data.get("total_words", 1)),
+        errors=errors,
+    )

--- a/src/ocr.py
+++ b/src/ocr.py
@@ -1,39 +1,95 @@
 """
 OCR module — extracts text from handwritten dictation images.
 
-Requires: tesseract with French language pack installed
+System requirement:
   macOS:  brew install tesseract tesseract-lang
   Ubuntu: sudo apt install tesseract-ocr tesseract-ocr-fra
 """
 
 import pytesseract
-from PIL import Image, ImageFilter, ImageEnhance
+from PIL import Image, ImageFilter, ImageEnhance, ImageOps
 import io
+from dataclasses import dataclass
+
+
+@dataclass
+class OCRResult:
+    text: str
+    confidence: float  # 0.0 – 1.0, estimated from Tesseract data
+    warning: str = ""
 
 
 def preprocess_image(image: Image.Image) -> Image.Image:
-    """Improve OCR accuracy: grayscale → sharpen → contrast boost."""
-    image = image.convert("L")  # grayscale
+    """
+    Improve OCR accuracy on handwritten text:
+    1. Grayscale — removes colour noise
+    2. Auto-contrast — normalises uneven lighting from phone photos
+    3. Sharpen — improves edge definition of handwritten strokes
+    4. Contrast boost — increases ink/paper separation
+    """
+    image = image.convert("L")
+    image = ImageOps.autocontrast(image, cutoff=2)
     image = image.filter(ImageFilter.SHARPEN)
-    image = ImageEnhance.Contrast(image).enhance(2.0)
+    image = ImageEnhance.Contrast(image).enhance(1.8)
     return image
 
 
-def extract_text_from_image(file) -> str:
+def extract_text_from_image(file) -> OCRResult:
     """
     Extract French text from an uploaded image file.
 
     Args:
-        file: Streamlit UploadedFile object (jpg/png)
+        file: Streamlit UploadedFile (jpg/jpeg/png) or file-like object
 
     Returns:
-        Extracted text string, stripped of excess whitespace.
+        OCRResult with extracted text, confidence estimate, and optional warning.
+
+    Raises:
+        RuntimeError: if tesseract is not installed or French pack is missing.
     """
-    image = Image.open(io.BytesIO(file.read()))
+    raw_bytes = file.read() if hasattr(file, "read") else file
+    image = Image.open(io.BytesIO(raw_bytes))
+
+    # Convert RGBA/P (PNG with transparency) to RGB before grayscale
+    if image.mode in ("RGBA", "P"):
+        image = image.convert("RGB")
+
     image = preprocess_image(image)
 
-    # lang='fra' is required for correct French character recognition
-    # including accented letters: é, è, ê, à, â, ù, û, ü, ï, ô, œ, æ, ç
-    text = pytesseract.image_to_string(image, lang="fra")
+    # lang='fra' is required for French — ensures accented characters
+    # (é, è, ê, à, â, ù, û, ü, ï, ô, œ, æ, ç) are recognised correctly.
+    try:
+        data = pytesseract.image_to_data(
+            image,
+            lang="fra",
+            output_type=pytesseract.Output.DICT,
+        )
+    except pytesseract.TesseractNotFoundError:
+        raise RuntimeError(
+            "Tesseract is not installed. "
+            "macOS: brew install tesseract tesseract-lang | "
+            "Ubuntu: sudo apt install tesseract-ocr tesseract-ocr-fra"
+        )
 
-    return text.strip()
+    # Build text and calculate mean confidence from non-empty words
+    words = []
+    confidences = []
+    for i, word in enumerate(data["text"]):
+        word = word.strip()
+        if word:
+            words.append(word)
+            conf = int(data["conf"][i])
+            if conf > 0:
+                confidences.append(conf)
+
+    text = " ".join(words).strip()
+    avg_conf = (sum(confidences) / len(confidences) / 100) if confidences else 0.0
+
+    warning = ""
+    if avg_conf < 0.5:
+        warning = (
+            "Low OCR confidence. The image may be blurry or the handwriting hard to read. "
+            "Please review the extracted text carefully."
+        )
+
+    return OCRResult(text=text, confidence=avg_conf, warning=warning)

--- a/tests/test_correction.py
+++ b/tests/test_correction.py
@@ -1,59 +1,119 @@
 """
 Tests for the correction module.
-
-These tests use a mock Claude client to avoid API calls during CI.
+Uses a mocked Anthropic client — no API calls during CI.
 """
 
+import json
 import pytest
 from unittest.mock import patch, MagicMock
-from src.correction import correct_dictation
+from src.correction import correct_dictation, CorrectionResult, DictationError
 
 
-MOCK_RESPONSE = {
-    "score": 80,
+def make_mock_client(response_data: dict):
+    mock_msg = MagicMock()
+    mock_msg.content = [MagicMock(text=json.dumps(response_data))]
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = mock_msg
+    return mock_client
+
+
+ONE_ERROR_RESPONSE = {
+    "score": 90,
     "total_words": 10,
     "errors": [
         {
             "wrong": "maison",
             "correct": "maisons",
             "type": "spelling",
-            "explanation": "Missing plural 's'",
+            "explanation": "Missing plural 's' — les maisons takes a plural noun.",
+        }
+    ],
+}
+
+PERFECT_RESPONSE = {
+    "score": 100,
+    "total_words": 6,
+    "errors": [],
+}
+
+ACCENT_ERROR_RESPONSE = {
+    "score": 80,
+    "total_words": 5,
+    "errors": [
+        {
+            "wrong": "eleve",
+            "correct": "élève",
+            "type": "accent",
+            "explanation": "Missing grave accents on both e's.",
         }
     ],
 }
 
 
-def make_mock_message(content: str):
-    msg = MagicMock()
-    msg.content = [MagicMock(text=content)]
-    return msg
-
-
 @patch("src.correction._get_client")
-def test_correct_dictation_returns_score(mock_get_client):
-    import json
-    mock_client = MagicMock()
-    mock_client.messages.create.return_value = make_mock_message(
-        json.dumps(MOCK_RESPONSE)
-    )
-    mock_get_client.return_value = mock_client
-
+def test_returns_correction_result(mock_get_client):
+    mock_get_client.return_value = make_mock_client(ONE_ERROR_RESPONSE)
     result = correct_dictation("les maison sont belles", "les maisons sont belles")
-
-    assert result["score"] == 80
-    assert len(result["errors"]) == 1
-    assert result["errors"][0]["type"] == "spelling"
+    assert isinstance(result, CorrectionResult)
+    assert result.score == 90
+    assert result.total_words == 10
+    assert result.error_count == 1
 
 
 @patch("src.correction._get_client")
-def test_perfect_dictation_no_errors(mock_get_client):
-    import json
-    perfect = {"score": 100, "total_words": 5, "errors": []}
+def test_error_fields_populated(mock_get_client):
+    mock_get_client.return_value = make_mock_client(ONE_ERROR_RESPONSE)
+    result = correct_dictation("les maison", "les maisons")
+    err = result.errors[0]
+    assert isinstance(err, DictationError)
+    assert err.wrong == "maison"
+    assert err.correct == "maisons"
+    assert err.type == "spelling"
+    assert "plural" in err.explanation.lower()
+
+
+@patch("src.correction._get_client")
+def test_perfect_dictation(mock_get_client):
+    mock_get_client.return_value = make_mock_client(PERFECT_RESPONSE)
+    result = correct_dictation("le chat mange", "le chat mange")
+    assert result.score == 100
+    assert result.errors == []
+    assert result.error_count == 0
+
+
+@patch("src.correction._get_client")
+def test_accent_error_type(mock_get_client):
+    mock_get_client.return_value = make_mock_client(ACCENT_ERROR_RESPONSE)
+    result = correct_dictation("un eleve", "un élève")
+    assert result.errors[0].type == "accent"
+
+
+@patch("src.correction._get_client")
+def test_errors_by_type_groups_correctly(mock_get_client):
+    response = {
+        "score": 60,
+        "total_words": 10,
+        "errors": [
+            {"wrong": "a", "correct": "à", "type": "accent", "explanation": "x"},
+            {"wrong": "b", "correct": "bb", "type": "spelling", "explanation": "x"},
+            {"wrong": "c", "correct": "cc", "type": "accent", "explanation": "x"},
+        ],
+    }
+    mock_get_client.return_value = make_mock_client(response)
+    result = correct_dictation("a b c", "à bb cc")
+    by_type = result.errors_by_type
+    assert by_type["accent"] == 2
+    assert by_type["spelling"] == 1
+
+
+@patch("src.correction._get_client")
+def test_handles_markdown_wrapped_json(mock_get_client):
+    wrapped = f"```json\n{json.dumps(PERFECT_RESPONSE)}\n```"
+    mock_msg = MagicMock()
+    mock_msg.content = [MagicMock(text=wrapped)]
     mock_client = MagicMock()
-    mock_client.messages.create.return_value = make_mock_message(json.dumps(perfect))
+    mock_client.messages.create.return_value = mock_msg
     mock_get_client.return_value = mock_client
 
-    result = correct_dictation("le chat mange", "le chat mange")
-
-    assert result["score"] == 100
-    assert result["errors"] == []
+    result = correct_dictation("le chat", "le chat")
+    assert result.score == 100

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,0 +1,73 @@
+"""
+Tests for the OCR module.
+Uses a mocked pytesseract to avoid requiring tesseract in CI.
+"""
+
+import io
+import pytest
+from unittest.mock import patch, MagicMock
+from PIL import Image
+from src.ocr import extract_text_from_image, preprocess_image, OCRResult
+
+
+def make_test_image(text: str = "test") -> bytes:
+    """Create a minimal white PNG image for testing."""
+    img = Image.new("RGB", (200, 50), color=(255, 255, 255))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    return buf.read()
+
+
+MOCK_TESS_DATA = {
+    "text": ["Le", "chat", "mange", ""],
+    "conf": [90, 85, 88, -1],
+}
+
+
+@patch("src.ocr.pytesseract.image_to_data")
+def test_extract_returns_ocr_result(mock_tess):
+    mock_tess.return_value = MOCK_TESS_DATA
+    file = io.BytesIO(make_test_image())
+    result = extract_text_from_image(file)
+    assert isinstance(result, OCRResult)
+    assert "Le" in result.text
+    assert result.confidence > 0
+
+
+@patch("src.ocr.pytesseract.image_to_data")
+def test_extract_joins_words(mock_tess):
+    mock_tess.return_value = MOCK_TESS_DATA
+    file = io.BytesIO(make_test_image())
+    result = extract_text_from_image(file)
+    assert result.text == "Le chat mange"
+
+
+@patch("src.ocr.pytesseract.image_to_data")
+def test_low_confidence_sets_warning(mock_tess):
+    low_conf_data = {
+        "text": ["abc", "def"],
+        "conf": [20, 15],
+    }
+    mock_tess.return_value = low_conf_data
+    file = io.BytesIO(make_test_image())
+    result = extract_text_from_image(file)
+    assert result.warning != ""
+    assert result.confidence < 0.5
+
+
+@patch("src.ocr.pytesseract.image_to_data")
+def test_rgba_image_handled(mock_tess):
+    mock_tess.return_value = MOCK_TESS_DATA
+    img = Image.new("RGBA", (200, 50), color=(255, 255, 255, 255))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    result = extract_text_from_image(buf)
+    assert isinstance(result, OCRResult)
+
+
+def test_preprocess_returns_grayscale():
+    img = Image.new("RGB", (100, 50), color=(200, 180, 160))
+    processed = preprocess_image(img)
+    assert processed.mode == "L"


### PR DESCRIPTION
## Sprint 1 MVP — Complete

This PR implements the full end-to-end flow for Sprint 1:
**Upload photo → OCR → Claude correction → Error report**

## What Changed

### `src/ocr.py`
- `OCRResult` dataclass with text, confidence (0–1), optional warning
- Image preprocessing pipeline: grayscale → autocontrast → sharpen → contrast boost
- Per-word confidence scoring via `image_to_data()`
- Low-confidence warning in UI when avg < 50%
- RGBA/P PNG transparency handled
- `lang='fra'` enforced for French accent recognition (é, è, ê, à, â, ç…)

### `src/correction.py`
- `CorrectionResult` dataclass: score, total_words, errors list
- `DictationError` dataclass: wrong, correct, type, explanation
- `errors_by_type` property for UI breakdown
- Claude `claude-sonnet-4-6` with strict system prompt
- 5 error types: `spelling`, `grammar`, `accent`, `missing_word`, `extra_word`
- Markdown code fence stripping from Claude response
- Lazy singleton Anthropic client

### `app.py`
- Full 3-step Streamlit UI: upload → OCR review → correction → report
- OCR confidence badge
- Editable OCR text area
- Score metrics, error type breakdown, per-error expanders
- `session_state` stores result for Sprint 2 PDF export

### Tests (11 passed ✅)
- `tests/test_correction.py`: 6 tests
- `tests/test_ocr.py`: 5 tests
- All mocked — no API calls or tesseract in CI

## Test Plan

- [x] `pytest tests/ -v` — 11 passed
- [x] No `.env` committed
- [x] `.venv/` excluded from git

## Linked Issues

Closes #3 · Closes #4 · Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)